### PR TITLE
fix SubscribeTipStream json Unmarshal error

### DIFF
--- a/pkg/util.go
+++ b/pkg/util.go
@@ -53,14 +53,14 @@ func SubscribeTipStream(ctx context.Context) (<-chan *TipStreamInfo, <-chan erro
 			case <-ctx.Done():
 				return
 			default:
-				var r *TipStreamInfo
-				if err = conn.ReadJSON(r); err != nil {
+				var r []*TipStreamInfo
+				if err = conn.ReadJSON(&r); err != nil {
 					chErr <- err
 					time.Sleep(500 * time.Millisecond)
 					continue
 				}
 
-				ch <- r
+				ch <- r[0]
 			}
 		}
 	}()


### PR DESCRIPTION
jito ws message is array of TipStreamInfo. current code get error ` json: Unmarshal(nil *pkg.TipStreamInfo)`

> [{"time":"2024-09-24T16:25:00Z","landed_tips_25th_percentile":1.001e-6,"landed_tips_50th_percentile":9.201e-6,"landed_tips_75th_percentile":0.000044932,"landed_tips_95th_percentile":0.001,"landed_tips_99th_percentile":0.012920015080000074,"ema_landed_tips_50th_percentile":9.44425e-6}]