### PR TITLE
jito Http clien SendBundle use Base58 encode transcation

### DIFF
--- a/clients/searcher_client/searcher.go
+++ b/clients/searcher_client/searcher.go
@@ -13,10 +13,8 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/gagliardetto/solana-go"
 	"github.com/gagliardetto/solana-go/programs/system"
 	"github.com/gagliardetto/solana-go/rpc"
-	"github.com/weeaa/jito-go/pb"
 	"github.com/weeaa/jito-go/pkg"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -330,7 +328,11 @@ func BroadcastBundle(client *http.Client, transactions []string) (*BroadcastBund
 
 // BroadcastBundleWithConfirmation sends a bundle of transactions on chain through Jito BlockEngine and waits for its confirmation.
 func BroadcastBundleWithConfirmation(ctx context.Context, client *http.Client, rpcConn *rpc.Client, transactions []*solana.Transaction) (*BroadcastBundleResponse, error) {
-	bundle, err := BroadcastBundle(client, pkg.ConvertBachTransactionsToString(transactions))
+	txsBase58, err := pkg.ConvertBachTransactionsToBase58(transactions)
+	if err != nil {
+		return nil, err
+	}
+	bundle, err := BroadcastBundle(client, txsBase58)
 	if err != nil {
 		return nil, err
 	}

--- a/clients/searcher_client/searcher.go
+++ b/clients/searcher_client/searcher.go
@@ -7,17 +7,18 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/gagliardetto/solana-go"
+	"github.com/gagliardetto/solana-go/programs/system"
+	"github.com/gagliardetto/solana-go/rpc"
+	"github.com/weeaa/jito-go/pb"
+	"github.com/weeaa/jito-go/pkg"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 	"io"
 	"math/rand"
 	"net/http"
 	"net/url"
 	"time"
-
-	"github.com/gagliardetto/solana-go/programs/system"
-	"github.com/gagliardetto/solana-go/rpc"
-	"github.com/weeaa/jito-go/pkg"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
 )
 
 // New creates a new Searcher Client instance.

--- a/pkg/convert.go
+++ b/pkg/convert.go
@@ -2,6 +2,8 @@ package pkg
 
 import (
 	bin "github.com/gagliardetto/binary"
+	"github.com/gagliardetto/solana-go"
+	"github.com/weeaa/jito-go/pb"
 )
 
 // ConvertTransactionToProtobufPacket converts a solana-go Transaction to a pb.Packet.

--- a/pkg/convert.go
+++ b/pkg/convert.go
@@ -2,8 +2,6 @@ package pkg
 
 import (
 	bin "github.com/gagliardetto/binary"
-	"github.com/gagliardetto/solana-go"
-	"github.com/weeaa/jito-go/pb"
 )
 
 // ConvertTransactionToProtobufPacket converts a solana-go Transaction to a pb.Packet.
@@ -63,6 +61,21 @@ func ConvertBatchProtobufPacketToTransaction(packets []*jito_pb.Packet) ([]*sola
 		txs = append(txs, tx)
 	}
 
+	return txs, nil
+}
+
+func ConvertBachTransactionsToBase58(transactions []*solana.Transaction) ([]string, error) {
+	txs := make([]string, len(transactions))
+	for i, tx := range transactions {
+		// marshal transaction to Binary
+		txBytes, err := tx.MarshalBinary()
+		if err != nil {
+			return nil, err
+		}
+		// Convert transaction Base58
+		txBase58 := base58.Encode(txBytes)
+		txs[i] = txBase58
+	}
 	return txs, nil
 }
 


### PR DESCRIPTION
According to the jito Http client instructions, for transactions using base58 encoding in sendBundle, the TransactionsToString method will return a 400 error. Please refer to the API documentation for the address https://docs.jito.wtf/en/latest/lowlatencytxnsend.html#sendbundle